### PR TITLE
Adds periodic Juju refresh on Public Legend Instance

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -1,0 +1,45 @@
+name: Refresh EKS FINOS Legend deployment
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Runs everyday at 00:00. (see https://crontab.guru)
+    - cron: '0 0 * * *'
+
+jobs:
+  build:
+    name: Trigger Juju refresh on EKS Deployment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Installing Dependencies
+        run: |
+          sudo snap install juju --classic
+
+      # We need the kubeconfig and the controllers.yaml file into our environment
+      # in order to login and refresh the charms.
+      - name: Adding Credentials
+        shell: bash
+        run: |
+          mkdir -p ~/.kube
+          mkdir -p ~/.local/share/juju
+          echo "${KUBECONFIG_B64}" | base64 -d > ~/.kube/config
+          echo "${CONTROLLERS_B64}" | base64 -d > ~/.local/share/juju/controllers.yaml
+
+          echo "${CONTROLLER_PASSWORD}" | juju login -u admin
+        env:
+          KUBECONFIG_B64: "${{ secrets.KUBECONFIG_B64 }}"
+          CONTROLLERS_B64: "${{ secrets.CONTROLLERS_B64 }}"
+          CONTROLLER_PASSWORD: "${{ secrets.CONTROLLER_PASSWORD }}"
+
+      - name: Refreshing Charms
+        run: |
+          juju switch finos-legend-controller
+          juju switch finos-legend
+
+          # If a charm is already at its latest revision, juju refresh will have a non-zero
+          # exit code, which will cause this job to fail and not refresh the rest of the charms.
+          # Ideally, juju would have an option to ignore such errors, or at least return a
+          # different exit code for this error case (currently, it returns 1).
+          juju refresh legend-engine || true
+          juju refresh legend-sdlc || true
+          juju refresh legend-studio || true

--- a/docs/periodic_job.md
+++ b/docs/periodic_job.md
@@ -1,0 +1,9 @@
+# FINOS Legend Juju EKS deployment - Periodic refresh
+
+The [Refresh EKS FINOS Legend deployment](../.github/workflows/scheduled.yaml) job will run periodically for a configured Juju EKS deployment and will refresh the Legend Engine, Studio, and SDLC charms to their latest revisions (including the Legend docker images associated the revisions). This job requires a few Secrets to be defined in the project repository (``Settings > Secrets > Actions > Repository secrets``):
+
+- ``KUBECONFIG_B64``: The EKS kubeconfig file in base64 format. The kubeconfig file is typically found in ``~/.kube/config``, and to can be transformed into base64 by running: ``cat ~/.kube/config | base64``.
+- ``CONTROLLERS_B64``: The Juju ``controllers.yaml`` file in base64 format. The file is typically found in ``~/.local/share/juju/controllers.yaml``. The file will contain information about all the locally known Juju Controllers, but only the one containing the Legend model is needed. To transform it into base64, run: ``cat ~/.local/share/juju/controllers.yaml | base64``.
+- ``CONTROLLER_PASSWORD``: The Juju Controller's admin password. It can be typically found found in ``~/.local/share/juju/accounts.yaml``. This password will be used to authenticate into the Juju Controller.
+
+Once the above repository secrets have been set, the job should succeed. A manual job can also be triggered by going to ``Actions > Refresh EKS FINOS Legend deployment > Run workflow``.


### PR DESCRIPTION
The job will run periodically, and will refresh the Legend Engine, Studio, and SDLC charms to their latest revisions for a configured Juju EKS deployment of FINOS Legend.

In order for the job to run properly, the following secrets need to be added: ``KUBECONFIG_B64``, ``CONTROLLERS_B64``, ``CONTROLLER_PASSWORD``.

Adds documentation about the job, including information about the secrets mentioned above.