### PR TITLE
Removes the || true from juju refresh

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -47,13 +47,9 @@ jobs:
           # Upgrade controller model
           juju upgrade-controller -c finos-legend
 
-          # If a charm is already at its latest revision, juju refresh will have a non-zero
-          # exit code, which will cause this job to fail and not refresh the rest of the charms.
-          # Ideally, juju would have an option to ignore such errors, or at least return a
-          # different exit code for this error case (currently, it returns 1).
-          juju refresh legend-engine || true
-          juju refresh legend-sdlc || true
-          juju refresh legend-studio || true
+          juju refresh legend-engine
+          juju refresh legend-sdlc
+          juju refresh legend-studio
           
           # Running juju status will show us the current revisions of the charms.
           juju status


### PR DESCRIPTION
A fix for this issue has been merged and released under juju 2.9.28.

Reference: https://bugs.launchpad.net/juju/+bug/1965902