### PR TITLE
actions: Adds action which checks the jobs status on related projects

### DIFF
--- a/.github/workflows/legend_status.yaml
+++ b/.github/workflows/legend_status.yaml
@@ -1,0 +1,74 @@
+name: FINOS Legend charms project status
+
+on:
+  workflow_dispatch:
+  schedule:
+     Runs everyday at 00:00. (see https://crontab.guru)
+    - cron: '0 0 * * *'
+
+jobs:
+  build:
+    name: Trigger Juju refresh on EKS Deployment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Installing Dependencies
+        run: |
+          # According to https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian-ubuntu-linux-raspberry-pi-os-apt
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+          sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          sudo apt update
+          sudo apt install gh
+
+      - name: Adding gh Credentials
+        env:
+          GH_TOKEN: "${{ secrets.GH_TOKEN }}"
+
+      - name: Check Legend charms project status
+        shell: bash
+        run: |
+          IGNORE_STATUS_JOB_NAME="FINOS Legend charms project status"
+          EXIT_CODE=0
+
+          OWNER="finos"
+          declare -a PROJECTS=(
+            "legend-integration-juju"
+            "legend-juju-bundle"
+            "legend-juju-studio-operator"
+            "legend-juju-sdlc-server-operator"
+            "legend-juju-engine-server-operator"
+            "legend-juju-gitlab-integrator"
+            "legend-juju-db-operator"
+          )
+
+          check_project_jobs(){
+            project="$1"
+
+            # We need this in order to preserve the whitespaces as they are written by gh,
+            # (columns separated by tabs), so we can cut them.
+            IFS=''
+            while read -r line
+            do
+              job_name="$(echo $line | cut -f1)"
+              state="$(echo $line | cut -f2)"
+              job_id="$(echo $line | cut -f3)"
+
+              # We need to filter gh workflow view's output to just the jobs runs.
+              # We'll check if the latest one was successful or not.
+              # Expected line: completed       success ...
+              job_status=$(gh workflow view --repo "${project}" "${job_id}" | grep "^completed" | head -n 1 | cut -f2)
+              printf "Project: %40s \t Job name: %35s \t State: %s \t Status: %s\n" "${project}" "${job_name}" "${state}" "${job_status}"
+
+              # Set the return code to 1 if a job had failed.
+              if [ "${job_name}" != "${IGNORE_STATUS_JOB_NAME}" ] && [ "${job_status}" = "failure" ]; then
+                EXIT_CODE=1
+              fi
+            done < <(gh workflow list --repo "${project}")
+          }
+
+          for project in ${PROJECTS[*]};
+          do
+            check_project_jobs "${OWNER}/${project}"
+          done
+
+          exit ${EXIT_CODE}

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ The [legend-juju-bundle](https://github.com/finos/legend-juju-bundle) repository
 
 Each repository has included in its ``README.md`` file and docs information about how their GitHub actions have been configured and what repositories secrets they require. In summary, they all require a Charmhub authentication token that has the permission to upload resources for the respective charms.
 
+This repository contains a [GitHub action](.github/workflows/legend_status.yaml) which queries the status of the jobs running on the [related repositories](#Related-Repositores), making it easier to check the health of the repositories and charm / bundle publishing processes.
+
 ## FINOS Legend Juju acceptance environment
 
 The [Juju acceptance environment](https://juju-acct.legend.finos.org/) has been deployed on EKS using the [EKS deployment guide](docs/deploy/aws-eks.md). This repository has been configured with a [GitHub action](.github/workflows/scheduled.yaml) that will update the Legend Engine, SDLC and Studio charms to their latest revisions (and thus, latest image versions).

--- a/docs/periodic_job.md
+++ b/docs/periodic_job.md
@@ -7,3 +7,7 @@ The [Refresh EKS FINOS Legend deployment](../.github/workflows/scheduled.yaml) j
 - ``CONTROLLER_PASSWORD``: The Juju Controller's admin password. It can be typically found found in ``~/.local/share/juju/accounts.yaml``. This password will be used to authenticate into the Juju Controller.
 
 Once the above repository secrets have been set, the job should succeed. A manual job can also be triggered by going to ``Actions > Refresh EKS FINOS Legend deployment > Run workflow``.
+
+# FINOS Legend charms project status - Periodic job
+
+The ``FINOS Legend charms project status`` [action](../.github/workflows/legend_status.yaml) queries the status of the jobs running on the related repositories, making it easier to check the health of the repositories and charm / bundle publishing processes. This action can also be manually dispatched. But in order for this action to work, the ``GH_TOKEN`` repository secret needs to be added. The token can be [generated](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with the ``repo, workflow`` scopes.


### PR DESCRIPTION
The Legend Juju Bundle has quite a few components spread across several repositories, which can make it a bit harder to track and ensure that everything is healthy.

This adds an action which will check the status of all the jobs of all the related projects, making it easier to maintain.