### PR TITLE
Pin `juju` to `v3.0.x` when refreshing deployment

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Installing Dependencies
         run: |
-          sudo snap install juju --classic
+          sudo snap install juju --channel=3.0/stable --classic
 
       - name: Install Docker
         uses: docker-practice/actions-setup-docker@master


### PR DESCRIPTION
By using `channel=3.0/stable` we pin the `juju` installation to version 3.0.x. This increases the deployment stability.
