### PR TITLE
Switches Public Instance controller to the newer one

### DIFF
--- a/.github/workflows/renew_certificate.yaml
+++ b/.github/workflows/renew_certificate.yaml
@@ -35,8 +35,8 @@ jobs:
       - name: Renewing Certificate
         run: |
 
-          # Controller and model names are the same, "finos-legend"
-          juju switch finos-legend:finos-legend
+          # Controller name is "finos-legend-v3", model name is "finos-legend"
+          juju switch finos-legend-v3:finos-legend
                     
           # Running juju status will show us the current revisions of the charms.
           juju status --relations

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -38,8 +38,8 @@ jobs:
       - name: Refreshing Charms
         run: |
 
-          # Controller and model names are the same, "finos-legend"
-          juju switch finos-legend:finos-legend
+          # Controller name is "finos-legend-v3", model name is "finos-legend"
+          juju switch finos-legend-v3:finos-legend
                     
           # Running juju status will show us the current revisions of the charms.
           juju status --relations


### PR DESCRIPTION
The FINOS Legend instance has been migrated to a Juju v3.0.2 controller.