### PR TITLE
Pin `juju` to `v3.0.x` when renewing certificates

### DIFF
--- a/.github/workflows/renew_certificate.yaml
+++ b/.github/workflows/renew_certificate.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Install Juju
         run: |
-          sudo snap install juju --classic
+          sudo snap install juju --channel=3.0/stable --classic
 
       # We need the kubeconfig and the controllers.yaml file into our environment
       # in order to login and refresh the charms.


### PR DESCRIPTION
We've switched to using Juju v3.0. The github action is using juju v3.0 specific commands and options.