### PR TITLE
Updates action success check

### DIFF
--- a/.github/workflows/renew_certificate.yaml
+++ b/.github/workflows/renew_certificate.yaml
@@ -44,7 +44,7 @@ jobs:
           # Run the renew action on the certbot-k8s charm.
           action_result=$(juju run certbot-k8s/0 renew-certificate --wait=10m)
 
-          if [[ $action_result != *"status: completed"* ]]; then
+          if [[ $? -ne 0 ]]; then
             echo "Certificate renewal failed:\n$action_result" 
             exit 1
           fi


### PR DESCRIPTION
``juju run`` doesn't include a status anymore. We can check the exit code instead.