### PR TITLE
Send email on failure of periodic workflow actions

### DIFF
--- a/.github/workflows/renew_certificate.yaml
+++ b/.github/workflows/renew_certificate.yaml
@@ -51,3 +51,16 @@ jobs:
 
           # Show the juju status to see if any errors occurred.
           juju status --relations
+
+      - name: Send email on failure
+        if: failure() && github.event_name == 'schedule'
+        uses: dawidd6/action-send-mail@v2
+        with:
+          server_address: ${{ secrets.EMAIL_SERVER }}
+          server_port: ${{ secrets.EMAIL_PORT }}
+          username: ${{ secrets.EMAIL_USERNAME }}
+          password: ${{ secrets.EMAIL_PASSWORD }}
+          subject: "${{ github.job }} job of ${{ github.repository }} has failed"
+          body: "${{ github.job }} job in worflow ${{ github.workflow }} of ${{ github.repository }} has failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          to: ${{ secrets.EMAIL_TO }}
+          from: ${{ secrets.EMAIL_FROM }}

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -111,3 +111,16 @@ jobs:
           wait_for_curl "https://juju-acct.legend.finos.org/engine"
 
           echo "Legend is reachable, getting redirected to gitlab."
+
+      - name: Send email on failure
+        if: failure() && github.event_name == 'schedule'
+        uses: dawidd6/action-send-mail@v2
+        with:
+          server_address: ${{ secrets.EMAIL_SERVER }}
+          server_port: ${{ secrets.EMAIL_PORT }}
+          username: ${{ secrets.EMAIL_USERNAME }}
+          password: ${{ secrets.EMAIL_PASSWORD }}
+          subject: "${{ github.job }} job of ${{ github.repository }} has failed"
+          body: "${{ github.job }} job in worflow ${{ github.workflow }} of ${{ github.repository }} has failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          to: ${{ secrets.EMAIL_TO }}
+          from: ${{ secrets.EMAIL_FROM }}

--- a/docs/periodic_job.md
+++ b/docs/periodic_job.md
@@ -6,4 +6,6 @@ The [Refresh EKS FINOS Legend deployment](../.github/workflows/scheduled.yaml) j
 - ``CONTROLLERS_B64``: The Juju ``controllers.yaml`` file in base64 format. The file is typically found in ``~/.local/share/juju/controllers.yaml``. The file will contain information about all the locally known Juju Controllers, but only the one containing the Legend model is needed. To transform it into base64, run: ``cat ~/.local/share/juju/controllers.yaml | base64``.
 - ``CONTROLLER_PASSWORD``: The Juju Controller's admin password. It can be typically found found in ``~/.local/share/juju/accounts.yaml``. This password will be used to authenticate into the Juju Controller.
 
+The action will also send an email in case of failure, so it needs email related secrets to be set up as well: `EMAIL_SERVER`, `EMAIL_PORT`, `EMAIL_USERNAME`, `EMAIL_PASSWORD`, `EMAIL_TO`, `EMAIL_FROM`.
+
 Once the above repository secrets have been set, the job should succeed. A manual job can also be triggered by going to ``Actions > Refresh EKS FINOS Legend deployment > Run workflow``.


### PR DESCRIPTION
If one of the periodic jobs fails, an email is sent. The email is only sent if the workflow action is triggered by the cron job.