### PR TITLE
actions: Update the actions for the staging model

### DIFF
--- a/.github/workflows/renew_certificate.yaml
+++ b/.github/workflows/renew_certificate.yaml
@@ -34,23 +34,28 @@ jobs:
 
       - name: Renewing Certificate
         run: |
+          renew_certificate() {
+            model=$1
+            juju switch "${model}"
+                    
+            # Running juju status will show us the current revisions of the charms.
+            juju status --relations
+
+            # Run the renew action on the certbot-k8s charm.
+            action_result=$(juju run certbot-k8s/0 renew-certificate --wait=10m)
+
+            if [[ $? -ne 0 ]]; then
+              echo "Certificate renewal failed:\n$action_result" 
+              exit 1
+            fi
+
+            # Show the juju status to see if any errors occurred.
+            juju status --relations
+          }
 
           # Controller name is "finos-legend-v3", model name is "finos-legend"
-          juju switch finos-legend-v3:finos-legend
-                    
-          # Running juju status will show us the current revisions of the charms.
-          juju status --relations
-
-          # Run the renew action on the certbot-k8s charm.
-          action_result=$(juju run certbot-k8s/0 renew-certificate --wait=10m)
-
-          if [[ $? -ne 0 ]]; then
-            echo "Certificate renewal failed:\n$action_result" 
-            exit 1
-          fi
-
-          # Show the juju status to see if any errors occurred.
-          juju status --relations
+          renew_certificate "finos-legend-v3:finos-legend"
+          renew_certificate "finos-legend-v3:finos-legend-twin"
 
       - name: Send email on failure
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -37,13 +37,21 @@ jobs:
 
       - name: Refreshing Charms
         run: |
+          set -x
+
+          # We only refresh the staging environment. We need to check which model
+          # is the staging one. We can find it by the configured external-hostname.
           # Controller name is "finos-legend-v3", model name is "finos-legend"
-          juju switch finos-legend-v3:finos-legend
+          model="finos-legend-v3:finos-legend"
+          if [ "$(juju config -m $model legend-studio external-hostname)" != "staging.legend.finos.org" ]; then
+            model="finos-legend-v3:finos-legend-twin"
+          fi
+
+          juju switch "${model}"
                     
           # Running juju status will show us the current revisions of the charms.
           juju status --relations
 
-          set -x
 
           update-images() {
             charm_name=$1 
@@ -105,11 +113,11 @@ jobs:
             done
           }
 
-          wait_for_curl "https://juju-acct.legend.finos.org/"
-          wait_for_curl "https://juju-acct.legend.finos.org/api"
-          wait_for_curl "https://juju-acct.legend.finos.org/engine"
+          wait_for_curl "https://staging.legend.finos.org/"
+          wait_for_curl "https://staging.legend.finos.org/api"
+          wait_for_curl "https://staging.legend.finos.org/engine"
 
-          echo "Legend is reachable, getting redirected to gitlab."
+          echo "Staging Legend is reachable, getting redirected to gitlab."
 
       - name: Send email on failure
         if: failure() && github.event_name == 'schedule'


### PR DESCRIPTION
The TLS certificate needs to be refreshed for both ``finos-legend`` and ``finos-legend-twin`` models.

For the Juju refresh action, it has been decided to only keep the staging model up-to-date and switch which of the models will become the prod model or the staging model. For this, we need to check which model is the staging one.