### PR TITLE
actions: Fix wrong Engine staging URL

### DIFF
--- a/.github/workflows/switch_env.yaml
+++ b/.github/workflows/switch_env.yaml
@@ -102,5 +102,5 @@ jobs:
 
           wait_for_curl "https://staging.legend.finos.org/"
           wait_for_curl "https://staging.legend.finos.org/api"
-          wait_for_curl "https://staging.finos.org/engine"
+          wait_for_curl "https://staging.legend.finos.org/engine"
           echo "staging.legend.finos.org is reachable, getting redirected to gitlab."


### PR DESCRIPTION
The DNS name is ``staging.legend.finos.org``.