### PR TITLE
actions: Disable Refresh EKS Legend deployment on switch

### DIFF
--- a/.github/workflows/switch_env.yaml
+++ b/.github/workflows/switch_env.yaml
@@ -80,6 +80,10 @@ jobs:
           juju config -m finos-legend-twin gitlab-integrator | juju config gitlab-integrator --file -
           juju config -m finos-legend-twin gitlab-integrator --file ./gitlab-config.yaml
 
+          # Disable the Refresh workflow, so it doesn't update the current Staging environment.
+          # According to the documentation, we can refer to it by its file name.
+          gh workflow disable scheduled.yaml
+
       - name: Check Legend Instances status
         run: |
           wait_for_curl() {


### PR DESCRIPTION
After switching the Legend environment staging and Prod environments, disable the Refresh EKS FINOS Legend deployment, so we have the ability to switch back if something went wrong with the new Prod environment. Otherwise, the daily action would refresh the staging environment to the latest version.

The disabled action will have to be enabled manually afterwards.