### PR TITLE
actions: Updates the scheduled refresh action check

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -102,9 +102,10 @@ jobs:
         run: |
           wait_for_curl() {
             url="$1"
+            expected_code="${2:-302 Found}"
             for i in {1..40}; do
               # Any request to any Legend Application should be redirected to gitlab.com
-              curl -i "${url}" | grep "302 Found" && break
+              curl -i "${url}" | grep "{expected_code}" && break
               if [ "$i" -eq 40 ]; then
                 echo "Failed to get '302 Found' response status from ${url}"
                 exit 1
@@ -115,7 +116,7 @@ jobs:
 
           wait_for_curl "https://staging.legend.finos.org/engine"
           wait_for_curl "https://staging.legend.finos.org/api"
-          wait_for_curl "https://staging.legend.finos.org/"
+          wait_for_curl "https://staging.legend.finos.org/" "200 OK"
 
           echo "Staging Legend is reachable, getting redirected to gitlab."
 


### PR DESCRIPTION
We've added an ingress "/" route for Legend docs to the staging model, which means that https://staging.legend.finos.org/ no longer returns a 302 Found HTTP code, but 200 OK instead.

Updates the "Refresh EKS FINOS Legend deployment" action to check for 200 OK for https://staging.legend.finos.org/