### PR TITLE
jobs: Adds set -e and set -x flags to the renew_certificate job

### DIFF
--- a/.github/workflows/renew_certificate.yaml
+++ b/.github/workflows/renew_certificate.yaml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Renewing Certificate
         run: |
+          set -x
+          set -e
           renew_certificate() {
             model=$1
             juju switch "${model}"


### PR DESCRIPTION
``set -e`` tells the script to exit the script if any command returns a non-zero exit status.

``set -x`` is useful for debugging, essentially allowing us to trace the script execution.